### PR TITLE
docs: fix simple typo, developement -> development

### DIFF
--- a/project_name/__local_settings.py
+++ b/project_name/__local_settings.py
@@ -19,5 +19,5 @@ DATABASES = {
 SECRET_KEY = ''
 
 if DEBUG:
-    # Show emails in the console during developement.
+    # Show emails in the console during development.
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/project_name/local_settings.py
+++ b/project_name/local_settings.py
@@ -19,5 +19,5 @@ DATABASES = {
 SECRET_KEY = '{{ secret_key }}'
 
 if DEBUG:
-    # Show emails in the console during developement.
+    # Show emails in the console during development.
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
There is a small typo in project_name/__local_settings.py, project_name/local_settings.py.

Should read `development` rather than `developement`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md